### PR TITLE
fix: Checker buttons doesn't work

### DIFF
--- a/lms/static/checker.js
+++ b/lms/static/checker.js
@@ -59,7 +59,7 @@ function trackAssessmentButtons() {
   });
 }
 
-window.addEventListener('lines-numbered', () => {
+window.addEventListener('defined-window-variables', () => {
   trackFinished(window.exerciseId, window.solutionId, document.getElementById('save-check'));
   trackAssessmentButtons();
 });

--- a/lms/static/comments.js
+++ b/lms/static/comments.js
@@ -240,6 +240,7 @@ window.markLine = markLine;
 window.removeMark = removeMark;
 window.hoverLine = hoverLine;
 window.addCommentToLine = addCommentToLine;
+
 window.addEventListener('load', () => {
   const codeElementData = document.getElementById('code-view').dataset;
   window.solutionId = codeElementData.id;
@@ -250,6 +251,11 @@ window.addEventListener('load', () => {
   sessionStorage.setItem('solverId', codeElementData.solverId);
   sessionStorage.setItem('allowedComment', codeElementData.allowedComment);
   customElements.define('comment-line', LineComment);
+  window.dispatchEvent(new Event('defined-window-variables'));
+});
+
+window.addEventListener('lines-numbered', () => {
   configureMarkdownParser();
   pullComments(window.fileId, treatComments);
+  window.dispatchEvent(new Event('fully-loaded'));
 });

--- a/lms/static/grader.js
+++ b/lms/static/grader.js
@@ -176,7 +176,7 @@ function addNewCommentButtons(elements) {
 
 window.deleteComment = deleteComment;
 window.sendExistsComment = sendExistsComment;
-window.addEventListener('lines-numbered', () => {
+window.addEventListener('fully-loaded', () => {
   const codeView = document.getElementById('code-view');
   const lineItems = codeView.getElementsByClassName('line');
   addNewCommentButtons(lineItems);

--- a/lms/static/solution.js
+++ b/lms/static/solution.js
@@ -32,6 +32,6 @@ function addLineSpansToPre(items) {
   window.dispatchEvent(new Event('lines-numbered'));
 }
 
-window.addEventListener('load', () => {
+window.addEventListener('defined-window-variables', () => {
   addLineSpansToPre(document.getElementsByTagName('code'));
 });


### PR DESCRIPTION
Bug that happens due to race condition.

We improved the <span> detection too much, and it caused a race condition where the fileId etc aren't defined when we're tracking the buttons.

The solution is to define loading order using event listeners.